### PR TITLE
feat: 실종 찾기 게시판

### DIFF
--- a/common/src/main/java/Hongik_SafeMap_Server/exception/ErrorMessage.java
+++ b/common/src/main/java/Hongik_SafeMap_Server/exception/ErrorMessage.java
@@ -20,4 +20,7 @@ public class ErrorMessage {
 
     // DisasterReport
     public static final String INVALID_DISASTER_REPORT = "해당 id를 가진 제보를 찾을 수 없습니다.";
+
+    // LostReport
+    public static final String LOST_REPORT_NOT_FOUND = "해당 id를 가진 실종신고를 찾을 수 없습니다.";
 }

--- a/common/src/main/java/Hongik_SafeMap_Server/exception/LostReportException.java
+++ b/common/src/main/java/Hongik_SafeMap_Server/exception/LostReportException.java
@@ -1,0 +1,7 @@
+package Hongik_SafeMap_Server.exception;
+
+public class LostReportException extends RuntimeException {
+    public LostReportException(String message) {
+        super(message);
+    }
+}

--- a/common/src/main/java/Hongik_SafeMap_Server/util/EnumUtil.java
+++ b/common/src/main/java/Hongik_SafeMap_Server/util/EnumUtil.java
@@ -1,0 +1,30 @@
+package Hongik_SafeMap_Server.util;
+
+public class EnumUtil {
+
+    public static <E extends Enum<E> & DescriptionProvider> E fromDescription(Class<E> enumClass, String description) {
+        if (description == null) {
+            return null;
+        }
+
+        for (E enumConstant : enumClass.getEnumConstants()) {
+            if (enumConstant.getDescription().equals(description)) {
+                return enumConstant;
+            }
+        }
+        throw new IllegalArgumentException("[" + description + "]은 유효하지 않은 " + getKoreanName(enumClass) + " 값입니다");
+    }
+
+    private static String getKoreanName(Class<?> enumClass) {
+        String simpleName = enumClass.getSimpleName();
+        return switch (simpleName) {
+            case "LostReportCategory" -> "카테고리";
+            case "LostReportStatus" -> "상태";
+            default -> simpleName;
+        };
+    }
+
+    public interface DescriptionProvider {
+        String getDescription();
+    }
+}

--- a/common/src/main/java/Hongik_SafeMap_Server/vo/LostReportCategory.java
+++ b/common/src/main/java/Hongik_SafeMap_Server/vo/LostReportCategory.java
@@ -1,0 +1,16 @@
+package Hongik_SafeMap_Server.vo;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum LostReportCategory {
+    PERSON("사람"),
+    PET("반려동물"),
+    BELONGINGS("소지품");
+
+    @JsonValue
+    private final String description;
+}

--- a/common/src/main/java/Hongik_SafeMap_Server/vo/LostReportCategory.java
+++ b/common/src/main/java/Hongik_SafeMap_Server/vo/LostReportCategory.java
@@ -1,16 +1,21 @@
 package Hongik_SafeMap_Server.vo;
 
+import Hongik_SafeMap_Server.util.EnumUtil;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum LostReportCategory {
+public enum LostReportCategory implements EnumUtil.DescriptionProvider {
     PERSON("사람"),
     PET("반려동물"),
     BELONGINGS("소지품");
 
     @JsonValue
     private final String description;
+    
+    public static LostReportCategory fromDescription(String description) {
+        return EnumUtil.fromDescription(LostReportCategory.class, description);
+    }
 }

--- a/common/src/main/java/Hongik_SafeMap_Server/vo/LostReportStatus.java
+++ b/common/src/main/java/Hongik_SafeMap_Server/vo/LostReportStatus.java
@@ -1,16 +1,21 @@
 package Hongik_SafeMap_Server.vo;
 
+import Hongik_SafeMap_Server.util.EnumUtil;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum LostReportStatus {
+public enum LostReportStatus implements EnumUtil.DescriptionProvider {
     IN_PROGRESS("진행중"),
     WAITING("대기중"),
     RESOLVED("해결됨");
 
     @JsonValue
     private final String description;
+    
+    public static LostReportStatus fromDescription(String description) {
+        return EnumUtil.fromDescription(LostReportStatus.class, description);
+    }
 }

--- a/common/src/main/java/Hongik_SafeMap_Server/vo/LostReportStatus.java
+++ b/common/src/main/java/Hongik_SafeMap_Server/vo/LostReportStatus.java
@@ -1,0 +1,16 @@
+package Hongik_SafeMap_Server.vo;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum LostReportStatus {
+    IN_PROGRESS("진행중"),
+    WAITING("대기중"),
+    RESOLVED("해결됨");
+
+    @JsonValue
+    private final String description;
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/config/EnumConverterConfig.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/config/EnumConverterConfig.java
@@ -1,0 +1,32 @@
+package Hongik_SafeMap_Server.config;
+
+import Hongik_SafeMap_Server.vo.LostReportCategory;
+import Hongik_SafeMap_Server.vo.LostReportStatus;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class EnumConverterConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new LostReportCategoryConverter());
+        registry.addConverter(new LostReportStatusConverter());
+    }
+
+    private static class LostReportCategoryConverter implements Converter<String, LostReportCategory> {
+        @Override
+        public LostReportCategory convert(String source) {
+            return LostReportCategory.fromDescription(source);
+        }
+    }
+
+    private static class LostReportStatusConverter implements Converter<String, LostReportStatus> {
+        @Override
+        public LostReportStatus convert(String source) {
+            return LostReportStatus.fromDescription(source);
+        }
+    }
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/config/SwaggerConfig.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/config/SwaggerConfig.java
@@ -1,45 +1,36 @@
 package Hongik_SafeMap_Server.config;
 
 import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.OpenAPI;
-import lombok.RequiredArgsConstructor;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import Hongik_SafeMap_Server.util.EnvironmentUtil;
-
-import java.util.List;
-
-import static Hongik_SafeMap_Server.constant.EnvironmentConstant.LOCAL_SERVER_URL;
 
 @Configuration
-@RequiredArgsConstructor
-@Profile({"local", "dev"})
+@Profile({"!prod"})
 public class SwaggerConfig {
-
-    private final EnvironmentUtil environmentUtil;
 
     @Bean
     public OpenAPI openAPI() {
-        String activeProfile = environmentUtil.getCurrentProfile();
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
 
-        Server server = new Server();
-        if (activeProfile.equalsIgnoreCase("local")) {
-            server.setUrl(LOCAL_SERVER_URL);
-        }
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("bearerAuth");
 
         return new OpenAPI()
-                .servers(List.of(server))
-                .components(new Components())
-                .info(apiInfo());
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .security(java.util.List.of(securityRequirement))
+                .info(new Info()
+                        .title("SafeMap Server API")
+                        .description("SafeMap 서버 API")
+                        .version("1.0.0"));
     }
-
-    private Info apiInfo() {
-        return new Info()
-                .title("Hongik SafeMap Server")
-                .version("1.0.0");
-    }
-
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/auth/dto/request/LoginRequest.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/auth/dto/request/LoginRequest.java
@@ -1,5 +1,6 @@
 package Hongik_SafeMap_Server.domain.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
@@ -9,6 +10,7 @@ import static Hongik_SafeMap_Server.exception.ErrorMessage.EMAIL_INVALID_FORMAT;
 import static Hongik_SafeMap_Server.exception.ErrorMessage.PASSWORD_INVALID_FORMAT;
 
 public record LoginRequest(
+        @Schema(description = "이메일", example = "user@naver.com")
         @NotBlank(message = "이메일을 입력해주세요.")
         @Pattern(
                 regexp = EMAIL_REGEX,
@@ -16,10 +18,12 @@ public record LoginRequest(
         )
         String email,
 
+        @Schema(description = "비밀번호", example = "safemap@1234")
         @NotBlank(message = "비밀번호를 입력해주세요.")
         @Pattern(
                 regexp = PASSWORD_REGEX,
                 message = PASSWORD_INVALID_FORMAT
         )
         String password
-) {}
+) {
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
@@ -2,6 +2,7 @@ package Hongik_SafeMap_Server.domain.lost_report.controller;
 
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCommentCreateRequest;
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequest;
+import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportUpdateRequest;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportCommentsResponse;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportResponse;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportsPageResponse;
@@ -77,6 +78,14 @@ public class LostReportController {
     @GetMapping("/{id}/comments")
     public ResponseEntity<LostReportCommentsResponse> getCommentsById(@PathVariable Long id) {
         LostReportCommentsResponse response = lostReportService.getComments(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "실종 신고 수정", description = "실종신고 게시물을 수정합니다. 작성자만 수정 가능합니다.")
+    @PutMapping("/{id}")
+    public ResponseEntity<LostReportResponse> update(@PathVariable Long id,
+                                                   @Valid @RequestBody LostReportUpdateRequest request) {
+        LostReportResponse response = lostReportService.update(id, request);
         return ResponseEntity.ok(response);
     }
 

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
@@ -1,5 +1,6 @@
 package Hongik_SafeMap_Server.domain.lost_report.controller;
 
+import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCommentCreateRequest;
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequest;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportResponse;
 import Hongik_SafeMap_Server.domain.lost_report.service.LostReportService;
@@ -31,5 +32,13 @@ public class LostReportController {
     public ResponseEntity<LostReportResponse> getById(@PathVariable Long id) {
         LostReportResponse response = lostReportService.getById(id);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "실종 신고 댓글 작성", description = "실종신고에 댓글을 작성합니다.")
+    @PostMapping("/{id}/comments")
+    public ResponseEntity<Long> createComment(@PathVariable Long id, 
+                                            @Valid @RequestBody LostReportCommentCreateRequest request) {
+        Long commentId = lostReportService.createComment(id, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(commentId);
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
@@ -1,0 +1,30 @@
+package Hongik_SafeMap_Server.domain.lost_report.controller;
+
+import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequest;
+import Hongik_SafeMap_Server.domain.lost_report.service.LostReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "실종 신고", description = "실종 신고 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/missing-board")
+public class LostReportController {
+
+    private final LostReportService lostReportService;
+
+    @Operation(summary = "실종 신고 등록", description = "실종자 정보를 등록합니다.")
+    @PostMapping
+    public ResponseEntity<Long> create(@Valid @RequestBody LostReportCreateRequest request) {
+        Long reportId = lostReportService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(reportId);
+    }
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
@@ -4,11 +4,17 @@ import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCommentCre
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequest;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportCommentsResponse;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportResponse;
+import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportsPageResponse;
 import Hongik_SafeMap_Server.domain.lost_report.service.LostReportService;
+import Hongik_SafeMap_Server.vo.LostReportCategory;
+import Hongik_SafeMap_Server.vo.LostReportStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +26,30 @@ import org.springframework.web.bind.annotation.*;
 public class LostReportController {
 
     private final LostReportService lostReportService;
+
+    @Operation(summary = "실종 신고 목록 조회", description = "실종신고 게시물 목록을 페이징으로 조회합니다. 카테고리나 상태로 필터링 가능합니다.")
+    @GetMapping
+    public ResponseEntity<LostReportsPageResponse> getAllLostReports(
+            @RequestParam(required = false) LostReportCategory category,
+            @RequestParam(required = false) LostReportStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        LostReportsPageResponse response;
+        
+        if (category != null && status != null) {
+            response = lostReportService.getLostReportsByCategoryAndStatus(category, status, pageable);
+        } else if (category != null) {
+            response = lostReportService.getLostReportsByCategory(category, pageable);
+        } else if (status != null) {
+            response = lostReportService.getLostReportsByStatus(status, pageable);
+        } else {
+            response = lostReportService.getLostReports(pageable);
+        }
+        
+        return ResponseEntity.ok(response);
+    }
 
     @Operation(summary = "실종 신고 등록", description = "실종자 정보를 등록합니다.")
     @PostMapping

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
@@ -2,6 +2,7 @@ package Hongik_SafeMap_Server.domain.lost_report.controller;
 
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCommentCreateRequest;
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequest;
+import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportCommentsResponse;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportResponse;
 import Hongik_SafeMap_Server.domain.lost_report.service.LostReportService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,9 +37,16 @@ public class LostReportController {
 
     @Operation(summary = "실종 신고 댓글 작성", description = "실종신고에 댓글을 작성합니다.")
     @PostMapping("/{id}/comments")
-    public ResponseEntity<Long> createComment(@PathVariable Long id, 
-                                            @Valid @RequestBody LostReportCommentCreateRequest request) {
+    public ResponseEntity<Long> createComment(@PathVariable Long id,
+                                              @Valid @RequestBody LostReportCommentCreateRequest request) {
         Long commentId = lostReportService.createComment(id, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(commentId);
+    }
+
+    @Operation(summary = "실종 신고 댓글 목록 조회", description = "실종신고 게시물의 댓글 목록을 조회합니다.")
+    @GetMapping("/{id}/comments")
+    public ResponseEntity<LostReportCommentsResponse> getCommentsById(@PathVariable Long id) {
+        LostReportCommentsResponse response = lostReportService.getComments(id);
+        return ResponseEntity.ok(response);
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
@@ -79,4 +79,11 @@ public class LostReportController {
         LostReportCommentsResponse response = lostReportService.getComments(id);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "실종 신고 삭제", description = "실종신고 게시물을 삭제합니다. 작성자만 삭제 가능합니다.")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        lostReportService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/controller/LostReportController.java
@@ -1,6 +1,7 @@
 package Hongik_SafeMap_Server.domain.lost_report.controller;
 
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequest;
+import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportResponse;
 import Hongik_SafeMap_Server.domain.lost_report.service.LostReportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -8,10 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "실종 신고", description = "실종 신고 관련 API")
 @RestController
@@ -26,5 +24,12 @@ public class LostReportController {
     public ResponseEntity<Long> create(@Valid @RequestBody LostReportCreateRequest request) {
         Long reportId = lostReportService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(reportId);
+    }
+
+    @Operation(summary = "실종 신고 상세 조회", description = "실종신고 ID로 상세 정보를 조회합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<LostReportResponse> getById(@PathVariable Long id) {
+        LostReportResponse response = lostReportService.getById(id);
+        return ResponseEntity.ok(response);
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/domain/LostReport.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/domain/LostReport.java
@@ -1,0 +1,81 @@
+package Hongik_SafeMap_Server.domain.lost_report.domain;
+
+import Hongik_SafeMap_Server.domain.member.domain.Member;
+import Hongik_SafeMap_Server.vo.LostReportCategory;
+import Hongik_SafeMap_Server.vo.LostReportStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "lost_report")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LostReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "lost_report_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "lost_report_category", nullable = false)
+    private LostReportCategory category;
+
+    @Column(name = "lost_report_title", length = 255, nullable = false)
+    private String title;
+
+    @Column(name = "lost_report_description", columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(name = "age", length = 20)
+    private String age;
+
+    @Column(name = "charitistic", length = 255, nullable = false)
+    private String characteristic;
+
+    @Column(name = "last_seen", length = 255, nullable = false)
+    private String lastSeen;
+
+    @Column(name = "current_location", length = 255, nullable = false)
+    private String currentLocation;
+
+    @Column(name = "timestamp", nullable = false)
+    private LocalDateTime timestamp;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "lost_report_status", nullable = false)
+    private LostReportStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ElementCollection
+    @CollectionTable(name = "lost_report_file", joinColumns = @JoinColumn(name = "lost_report_id"))
+    @Column(name = "file_url", length = 500)
+    private List<String> fileUrls = new ArrayList<>();
+
+    @Builder
+    public LostReport(LostReportCategory category, String title, String description, String age, 
+                     String characteristic, String lastSeen, String currentLocation, 
+                     Member member, List<String> fileUrls) {
+        this.category = category;
+        this.title = title;
+        this.description = description;
+        this.age = age;
+        this.characteristic = characteristic;
+        this.lastSeen = lastSeen;
+        this.currentLocation = currentLocation;
+        this.timestamp = LocalDateTime.now();
+        this.status = LostReportStatus.IN_PROGRESS;
+        this.member = member;
+        this.fileUrls = fileUrls != null ? new ArrayList<>(fileUrls) : new ArrayList<>();
+    }
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/domain/LostReport.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/domain/LostReport.java
@@ -37,7 +37,7 @@ public class LostReport {
     @Column(name = "age", length = 20)
     private String age;
 
-    @Column(name = "charitistic", length = 255, nullable = false)
+    @Column(name = "characteristic", length = 255, nullable = false)
     private String characteristic;
 
     @Column(name = "last_seen", length = 255, nullable = false)
@@ -46,8 +46,8 @@ public class LostReport {
     @Column(name = "current_location", length = 255, nullable = false)
     private String currentLocation;
 
-    @Column(name = "timestamp", nullable = false)
-    private LocalDateTime timestamp;
+    @Column(name = "createdAt", nullable = false)
+    private LocalDateTime createdAt;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "lost_report_status", nullable = false)
@@ -73,7 +73,7 @@ public class LostReport {
         this.characteristic = characteristic;
         this.lastSeen = lastSeen;
         this.currentLocation = currentLocation;
-        this.timestamp = LocalDateTime.now();
+        this.createdAt = LocalDateTime.now();
         this.status = LostReportStatus.IN_PROGRESS;
         this.member = member;
         this.fileUrls = fileUrls != null ? new ArrayList<>(fileUrls) : new ArrayList<>();

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/domain/LostReport.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/domain/LostReport.java
@@ -85,4 +85,17 @@ public class LostReport {
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void update(LostReportCategory category, LostReportStatus status, String title, String description, String age,
+                       String characteristic, String lastSeen, String currentLocation, List<String> fileUrls) {
+        this.category = category;
+        this.status = status;
+        this.title = title;
+        this.description = description;
+        this.age = age;
+        this.characteristic = characteristic;
+        this.lastSeen = lastSeen;
+        this.currentLocation = currentLocation;
+        this.fileUrls = fileUrls != null ? new ArrayList<>(fileUrls) : new ArrayList<>();
+    }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/domain/LostReport.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/domain/LostReport.java
@@ -49,6 +49,9 @@ public class LostReport {
     @Column(name = "createdAt", nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "deletedAt")
+    private LocalDateTime deletedAt;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "lost_report_status", nullable = false)
     private LostReportStatus status;
@@ -63,9 +66,9 @@ public class LostReport {
     private List<String> fileUrls = new ArrayList<>();
 
     @Builder
-    public LostReport(LostReportCategory category, String title, String description, String age, 
-                     String characteristic, String lastSeen, String currentLocation, 
-                     Member member, List<String> fileUrls) {
+    public LostReport(LostReportCategory category, String title, String description, String age,
+                      String characteristic, String lastSeen, String currentLocation,
+                      Member member, List<String> fileUrls) {
         this.category = category;
         this.title = title;
         this.description = description;
@@ -77,5 +80,9 @@ public class LostReport {
         this.status = LostReportStatus.IN_PROGRESS;
         this.member = member;
         this.fileUrls = fileUrls != null ? new ArrayList<>(fileUrls) : new ArrayList<>();
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/domain/LostReportComment.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/domain/LostReportComment.java
@@ -1,0 +1,44 @@
+package Hongik_SafeMap_Server.domain.lost_report.domain;
+
+import Hongik_SafeMap_Server.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "lost_report_comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LostReportComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "실종신고댓글아이디")
+    private Long id;
+
+    @Column(name = "실종신고댓글", length = 255, nullable = false)
+    private String content;
+
+    @Column(name = "댓글생성시간", nullable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "회원아이디", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "실종신고아아디", nullable = false)
+    private LostReport lostReport;
+
+    @Builder
+    public LostReportComment(String content, Member member, LostReport lostReport) {
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+        this.member = member;
+        this.lostReport = lostReport;
+    }
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/request/LostReportCommentCreateRequest.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/request/LostReportCommentCreateRequest.java
@@ -1,0 +1,12 @@
+package Hongik_SafeMap_Server.domain.lost_report.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "실종신고 댓글 작성 요청")
+public record LostReportCommentCreateRequest(
+        @Schema(description = "댓글 내용", example = "제가 어제 그 근처에서 봤어요!")
+        @NotBlank(message = "댓글 내용은 필수입니다")
+        String content
+) {
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/request/LostReportCreateRequest.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/request/LostReportCreateRequest.java
@@ -1,0 +1,42 @@
+package Hongik_SafeMap_Server.domain.lost_report.dto.request;
+
+import Hongik_SafeMap_Server.vo.LostReportCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+@Schema(description = "실종신고 등록 요청")
+public record LostReportCreateRequest(
+        @Schema(description = "카테고리", example = "사람")
+        @NotNull(message = "카테고리는 필수입니다")
+        LostReportCategory category,
+
+        @Schema(description = "제목", example = "할머니를 찾습니다")
+        @NotBlank(message = "제목은 필수입니다")
+        String title,
+
+        @Schema(description = "상세 설명", example = "실종 상황을 설명...")
+        @NotBlank(message = "상세 설명은 필수입니다")
+        String description,
+
+        @Schema(description = "나이/연령", example = "72세")
+        String age,
+
+        @Schema(description = "특징", example = "흰머리, 빨간 외투")
+        @NotBlank(message = "특징은 필수입니다")
+        String characteristic,
+
+        @Schema(description = "마지막 목격 장소", example = "서울시 강남구 역삼동")
+        @NotBlank(message = "마지막 목격 장소는 필수입니다")
+        String lastSeen,
+
+        @Schema(description = "현재 위치 (알림 범위)", example = "서울시 강남구 역삼동")
+        @NotBlank(message = "현재 위치는 필수입니다")
+        String currentLocation,
+
+        @Schema(description = "S3 업로드된 파일 URL 목록")
+        List<String> fileUrls
+) {
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/request/LostReportUpdateRequest.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/request/LostReportUpdateRequest.java
@@ -1,0 +1,47 @@
+package Hongik_SafeMap_Server.domain.lost_report.dto.request;
+
+import Hongik_SafeMap_Server.vo.LostReportCategory;
+import Hongik_SafeMap_Server.vo.LostReportStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+@Schema(description = "실종신고 수정 요청")
+public record LostReportUpdateRequest(
+        @Schema(description = "카테고리", example = "사람")
+        @NotNull(message = "카테고리는 필수입니다")
+        LostReportCategory category,
+
+        @Schema(description = "상태", example = "진행중")
+        @NotNull(message = "상태는 필수입니다")
+        LostReportStatus status,
+
+        @Schema(description = "제목", example = "할머니를 찾습니다")
+        @NotBlank(message = "제목은 필수입니다")
+        String title,
+
+        @Schema(description = "상세 설명", example = "실종 상황을 설명...")
+        @NotBlank(message = "상세 설명은 필수입니다")
+        String description,
+
+        @Schema(description = "나이/연령", example = "72세")
+        String age,
+
+        @Schema(description = "특징", example = "흰머리, 빨간 외투")
+        @NotBlank(message = "특징은 필수입니다")
+        String characteristic,
+
+        @Schema(description = "마지막 목격 장소", example = "서울시 강남구 역삼동")
+        @NotBlank(message = "마지막 목격 장소는 필수입니다")
+        String lastSeen,
+
+        @Schema(description = "현재 위치 (알림 범위)", example = "서울시 강남구 역삼동")
+        @NotBlank(message = "현재 위치는 필수입니다")
+        String currentLocation,
+
+        @Schema(description = "S3 업로드된 파일 URL 목록")
+        List<String> fileUrls
+) {
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportCommentResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportCommentResponse.java
@@ -1,0 +1,34 @@
+package Hongik_SafeMap_Server.domain.lost_report.dto.response;
+
+import Hongik_SafeMap_Server.domain.lost_report.domain.LostReportComment;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "실종 신고 댓글 응답")
+public record LostReportCommentResponse(
+        @Schema(description = "댓글 ID", example = "1")
+        Long id,
+
+        @Schema(description = "댓글 내용", example = "제가 어제 그 근처에서 봤어요!")
+        String content,
+
+        @Schema(description = "작성 시각")
+        LocalDateTime createdAt,
+
+        @Schema(description = "작성자 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "작성자", example = "홍길동")
+        String memberName
+) {
+    public static LostReportCommentResponse of(LostReportComment lostReportComment) {
+        return new LostReportCommentResponse(
+                lostReportComment.getId(),
+                lostReportComment.getContent(),
+                lostReportComment.getCreatedAt(),
+                lostReportComment.getMember().getId(),
+                lostReportComment.getMember().getName()
+        );
+    }
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportCommentsResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportCommentsResponse.java
@@ -1,0 +1,15 @@
+package Hongik_SafeMap_Server.domain.lost_report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "실종 신고 게시물 댓글 목록 응답")
+public record LostReportCommentsResponse(
+        @Schema(description = "댓글 개수", example = "2")
+        int totalCount,
+
+        @Schema(description = "댓글 목록")
+        List<LostReportCommentResponse> comments
+) {
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportResponse.java
@@ -44,7 +44,10 @@ public record LostReportResponse(
         List<String> fileUrls,
 
         @Schema(description = "신고자 ID", example = "1")
-        Long memberId
+        Long memberId,
+
+        @Schema(description = "신고자 이름", example = "홍길동")
+        String memberName
 ) {
     public static LostReportResponse of(LostReport lostReport) {
         return new LostReportResponse(
@@ -59,7 +62,8 @@ public record LostReportResponse(
                 lostReport.getCreatedAt(),
                 lostReport.getStatus(),
                 lostReport.getFileUrls(),
-                lostReport.getMember().getId()
+                lostReport.getMember().getId(),
+                lostReport.getMember().getName()
         );
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportResponse.java
@@ -1,0 +1,65 @@
+package Hongik_SafeMap_Server.domain.lost_report.dto.response;
+
+import Hongik_SafeMap_Server.domain.lost_report.domain.LostReport;
+import Hongik_SafeMap_Server.vo.LostReportCategory;
+import Hongik_SafeMap_Server.vo.LostReportStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "실종신고 조회 응답")
+public record LostReportResponse(
+        @Schema(description = "실종신고 ID", example = "1")
+        Long id,
+
+        @Schema(description = "카테고리", example = "사람")
+        LostReportCategory category,
+
+        @Schema(description = "제목", example = "할머니를 찾습니다")
+        String title,
+
+        @Schema(description = "상세 설명", example = "실종 상황을 설명...")
+        String description,
+
+        @Schema(description = "나이/연령", example = "72세")
+        String age,
+
+        @Schema(description = "특징", example = "흰머리, 빨간 외투")
+        String characteristic,
+
+        @Schema(description = "마지막 목격 장소", example = "서울시 강남구 역삼동")
+        String lastSeen,
+
+        @Schema(description = "현재 위치", example = "서울시 강남구 역삼동")
+        String currentLocation,
+
+        @Schema(description = "신고 시각")
+        LocalDateTime timestamp,
+
+        @Schema(description = "상태", example = "진행중")
+        LostReportStatus status,
+
+        @Schema(description = "파일 URL 목록")
+        List<String> fileUrls,
+
+        @Schema(description = "신고자 ID", example = "1")
+        Long memberId
+) {
+    public static LostReportResponse of(LostReport lostReport) {
+        return new LostReportResponse(
+                lostReport.getId(),
+                lostReport.getCategory(),
+                lostReport.getTitle(),
+                lostReport.getDescription(),
+                lostReport.getAge(),
+                lostReport.getCharacteristic(),
+                lostReport.getLastSeen(),
+                lostReport.getCurrentLocation(),
+                lostReport.getTimestamp(),
+                lostReport.getStatus(),
+                lostReport.getFileUrls(),
+                lostReport.getMember().getId()
+        );
+    }
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportResponse.java
@@ -47,9 +47,12 @@ public record LostReportResponse(
         Long memberId,
 
         @Schema(description = "신고자 이름", example = "홍길동")
-        String memberName
+        String memberName,
+
+        @Schema(description = "댓글 개수", example = "5")
+        long commentCount
 ) {
-    public static LostReportResponse of(LostReport lostReport) {
+    public static LostReportResponse of(LostReport lostReport, long commentCount) {
         return new LostReportResponse(
                 lostReport.getId(),
                 lostReport.getCategory(),
@@ -63,7 +66,8 @@ public record LostReportResponse(
                 lostReport.getStatus(),
                 lostReport.getFileUrls(),
                 lostReport.getMember().getId(),
-                lostReport.getMember().getName()
+                lostReport.getMember().getName(),
+                commentCount
         );
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportResponse.java
@@ -34,8 +34,8 @@ public record LostReportResponse(
         @Schema(description = "현재 위치", example = "서울시 강남구 역삼동")
         String currentLocation,
 
-        @Schema(description = "신고 시각")
-        LocalDateTime timestamp,
+        @Schema(description = "작성 시각")
+        LocalDateTime createdAt,
 
         @Schema(description = "상태", example = "진행중")
         LostReportStatus status,
@@ -56,7 +56,7 @@ public record LostReportResponse(
                 lostReport.getCharacteristic(),
                 lostReport.getLastSeen(),
                 lostReport.getCurrentLocation(),
-                lostReport.getTimestamp(),
+                lostReport.getCreatedAt(),
                 lostReport.getStatus(),
                 lostReport.getFileUrls(),
                 lostReport.getMember().getId()

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportsPageResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportsPageResponse.java
@@ -1,0 +1,29 @@
+package Hongik_SafeMap_Server.domain.lost_report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record LostReportsPageResponse(
+        @Schema(description = "게시글 목록")
+        List<LostReportResponse> reports,
+        
+        @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+        int currentPage,
+        
+        @Schema(description = "페이지 크기", example = "10")
+        int pageSize,
+        
+        @Schema(description = "총 게시글 개수", example = "100")
+        long totalElements,
+        
+        @Schema(description = "총 페이지 개수", example = "10")
+        int totalPages,
+        
+        @Schema(description = "첫 번째 페이지 여부", example = "true")
+        boolean first,
+        
+        @Schema(description = "마지막 페이지 여부", example = "false")
+        boolean last
+) {
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportsResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/dto/response/LostReportsResponse.java
@@ -1,0 +1,14 @@
+package Hongik_SafeMap_Server.domain.lost_report.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record LostReportsResponse(
+        @Schema(description = "게시글 개수", example = "1")
+        int totalCount,
+
+        @Schema(description = "게시글 목록")
+        List<LostReportResponse> reports
+) {
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportCommentRepository.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportCommentRepository.java
@@ -1,0 +1,9 @@
+package Hongik_SafeMap_Server.domain.lost_report.repository;
+
+import Hongik_SafeMap_Server.domain.lost_report.domain.LostReportComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LostReportCommentRepository extends JpaRepository<LostReportComment, Long> {
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportCommentRepository.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportCommentRepository.java
@@ -9,4 +9,7 @@ import java.util.List;
 @Repository
 public interface LostReportCommentRepository extends JpaRepository<LostReportComment, Long> {
     List<LostReportComment> findByLostReportIdOrderByCreatedAtAsc(Long lostReportId);
+    
+    // 게시글별 댓글 개수 조회
+    long countByLostReportId(Long lostReportId);
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportCommentRepository.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportCommentRepository.java
@@ -4,6 +4,9 @@ import Hongik_SafeMap_Server.domain.lost_report.domain.LostReportComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface LostReportCommentRepository extends JpaRepository<LostReportComment, Long> {
+    List<LostReportComment> findByLostReportIdOrderByCreatedAtAsc(Long lostReportId);
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportRepository.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportRepository.java
@@ -1,9 +1,49 @@
 package Hongik_SafeMap_Server.domain.lost_report.repository;
 
 import Hongik_SafeMap_Server.domain.lost_report.domain.LostReport;
+import Hongik_SafeMap_Server.global.dto.response.LostReportWithCommentCount;
+import Hongik_SafeMap_Server.vo.LostReportCategory;
+import Hongik_SafeMap_Server.vo.LostReportStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface LostReportRepository extends JpaRepository<LostReport, Long> {
+    
+
+    // 댓글 개수와 함께 전체 목록 조회 (최신순, 페이징)
+    @Query("SELECT new Hongik_SafeMap_Server.global.dto.response.LostReportWithCommentCount(lr, COUNT(lrc)) " +
+           "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
+           "GROUP BY lr")
+    Page<LostReportWithCommentCount> findAllWithCommentCount(Pageable pageable);
+
+    // 댓글 개수와 함께 카테고리별 조회 (최신순, 페이징)
+    @Query("SELECT new Hongik_SafeMap_Server.global.dto.response.LostReportWithCommentCount(lr, COUNT(lrc)) " +
+           "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
+           "WHERE lr.category = :category " +
+           "GROUP BY lr")
+    Page<LostReportWithCommentCount> findByCategoryWithCommentCount(@Param("category") LostReportCategory category, Pageable pageable);
+
+    // 댓글 개수와 함께 상태별 조회 (최신순, 페이징)
+    @Query("SELECT new Hongik_SafeMap_Server.global.dto.response.LostReportWithCommentCount(lr, COUNT(lrc)) " +
+           "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
+           "WHERE lr.status = :status " +
+           "GROUP BY lr")
+    Page<LostReportWithCommentCount> findByStatusWithCommentCount(@Param("status") LostReportStatus status, Pageable pageable);
+
+    // 댓글 개수와 함께 카테고리 + 상태별 조회 (최신순, 페이징)
+    @Query("SELECT new Hongik_SafeMap_Server.global.dto.response.LostReportWithCommentCount(lr, COUNT(lrc)) " +
+           "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
+           "WHERE lr.category = :category AND lr.status = :status " +
+           "GROUP BY lr")
+    Page<LostReportWithCommentCount> findByCategoryAndStatusWithCommentCount(
+            @Param("category") LostReportCategory category, 
+            @Param("status") LostReportStatus status, 
+            Pageable pageable);
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportRepository.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportRepository.java
@@ -11,39 +11,44 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface LostReportRepository extends JpaRepository<LostReport, Long> {
-    
 
-    // 댓글 개수와 함께 전체 목록 조회 (최신순, 페이징)
+
+    // 댓글 개수와 함께 전체 목록 조회 (삭제되지 않은 것만, 최신순, 페이징)
     @Query("SELECT new Hongik_SafeMap_Server.global.dto.response.LostReportWithCommentCount(lr, COUNT(lrc)) " +
-           "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
-           "GROUP BY lr")
+            "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
+            "WHERE lr.deletedAt IS NULL " +
+            "GROUP BY lr")
     Page<LostReportWithCommentCount> findAllWithCommentCount(Pageable pageable);
 
-    // 댓글 개수와 함께 카테고리별 조회 (최신순, 페이징)
+    // 댓글 개수와 함께 카테고리별 조회 (삭제되지 않은 것만, 최신순, 페이징)
     @Query("SELECT new Hongik_SafeMap_Server.global.dto.response.LostReportWithCommentCount(lr, COUNT(lrc)) " +
-           "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
-           "WHERE lr.category = :category " +
-           "GROUP BY lr")
+            "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
+            "WHERE lr.deletedAt IS NULL AND lr.category = :category " +
+            "GROUP BY lr")
     Page<LostReportWithCommentCount> findByCategoryWithCommentCount(@Param("category") LostReportCategory category, Pageable pageable);
 
-    // 댓글 개수와 함께 상태별 조회 (최신순, 페이징)
+    // 댓글 개수와 함께 상태별 조회 (삭제되지 않은 것만, 최신순, 페이징)
     @Query("SELECT new Hongik_SafeMap_Server.global.dto.response.LostReportWithCommentCount(lr, COUNT(lrc)) " +
-           "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
-           "WHERE lr.status = :status " +
-           "GROUP BY lr")
+            "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
+            "WHERE lr.deletedAt IS NULL AND lr.status = :status " +
+            "GROUP BY lr")
     Page<LostReportWithCommentCount> findByStatusWithCommentCount(@Param("status") LostReportStatus status, Pageable pageable);
 
-    // 댓글 개수와 함께 카테고리 + 상태별 조회 (최신순, 페이징)
+    // 댓글 개수와 함께 카테고리 + 상태별 조회 (삭제되지 않은 것만, 최신순, 페이징)
     @Query("SELECT new Hongik_SafeMap_Server.global.dto.response.LostReportWithCommentCount(lr, COUNT(lrc)) " +
-           "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
-           "WHERE lr.category = :category AND lr.status = :status " +
-           "GROUP BY lr")
+            "FROM LostReport lr LEFT JOIN LostReportComment lrc ON lr.id = lrc.lostReport.id " +
+            "WHERE lr.deletedAt IS NULL AND lr.category = :category AND lr.status = :status " +
+            "GROUP BY lr")
     Page<LostReportWithCommentCount> findByCategoryAndStatusWithCommentCount(
-            @Param("category") LostReportCategory category, 
-            @Param("status") LostReportStatus status, 
+            @Param("category") LostReportCategory category,
+            @Param("status") LostReportStatus status,
             Pageable pageable);
+
+    // 삭제되지 않은 게시물만 조회
+    @Query("SELECT lr FROM LostReport lr WHERE lr.id = :id AND lr.deletedAt IS NULL")
+    Optional<LostReport> findByIdAndNotDeleted(@Param("id") Long id);
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportRepository.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/repository/LostReportRepository.java
@@ -1,0 +1,9 @@
+package Hongik_SafeMap_Server.domain.lost_report.repository;
+
+import Hongik_SafeMap_Server.domain.lost_report.domain.LostReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LostReportRepository extends JpaRepository<LostReport, Long> {
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
@@ -7,12 +7,18 @@ import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequ
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportCommentResponse;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportCommentsResponse;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportResponse;
+import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportsPageResponse;
 import Hongik_SafeMap_Server.domain.lost_report.repository.LostReportCommentRepository;
 import Hongik_SafeMap_Server.domain.lost_report.repository.LostReportRepository;
 import Hongik_SafeMap_Server.domain.member.domain.Member;
 import Hongik_SafeMap_Server.exception.LostReportException;
+import Hongik_SafeMap_Server.global.dto.response.LostReportWithCommentCount;
 import Hongik_SafeMap_Server.util.MemberUtil;
+import Hongik_SafeMap_Server.vo.LostReportCategory;
+import Hongik_SafeMap_Server.vo.LostReportStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,7 +58,42 @@ public class LostReportService {
     public LostReportResponse getById(Long id) {
         LostReport lostReport = lostReportRepository.findById(id)
                 .orElseThrow(() -> new LostReportException(LOST_REPORT_NOT_FOUND));
-        return LostReportResponse.of(lostReport);
+
+        long commentCount = lostReportCommentRepository.countByLostReportId(id);
+
+        return LostReportResponse.of(lostReport, commentCount);
+    }
+
+    public LostReportsPageResponse getLostReports(Pageable pageable) {
+        return createLostReportsPageResponse(lostReportRepository.findAllWithCommentCount(pageable));
+    }
+
+    public LostReportsPageResponse getLostReportsByCategory(LostReportCategory category, Pageable pageable) {
+        return createLostReportsPageResponse(lostReportRepository.findByCategoryWithCommentCount(category, pageable));
+    }
+
+    public LostReportsPageResponse getLostReportsByStatus(LostReportStatus status, Pageable pageable) {
+        return createLostReportsPageResponse(lostReportRepository.findByStatusWithCommentCount(status, pageable));
+    }
+
+    public LostReportsPageResponse getLostReportsByCategoryAndStatus(LostReportCategory category, LostReportStatus status, Pageable pageable) {
+        return createLostReportsPageResponse(lostReportRepository.findByCategoryAndStatusWithCommentCount(category, status, pageable));
+    }
+
+    private LostReportsPageResponse createLostReportsPageResponse(Page<LostReportWithCommentCount> page) {
+        List<LostReportResponse> reportResponses = page.getContent().stream()
+                .map(dto -> LostReportResponse.of(dto.lostReport(), dto.commentCount()))
+                .toList();
+
+        return new LostReportsPageResponse(
+                reportResponses,
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isFirst(),
+                page.isLast()
+        );
     }
 
     @Transactional

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
@@ -4,6 +4,8 @@ import Hongik_SafeMap_Server.domain.lost_report.domain.LostReport;
 import Hongik_SafeMap_Server.domain.lost_report.domain.LostReportComment;
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCommentCreateRequest;
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequest;
+import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportCommentResponse;
+import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportCommentsResponse;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportResponse;
 import Hongik_SafeMap_Server.domain.lost_report.repository.LostReportCommentRepository;
 import Hongik_SafeMap_Server.domain.lost_report.repository.LostReportRepository;
@@ -13,6 +15,8 @@ import Hongik_SafeMap_Server.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static Hongik_SafeMap_Server.exception.ErrorMessage.LOST_REPORT_NOT_FOUND;
 
@@ -54,7 +58,7 @@ public class LostReportService {
     @Transactional
     public Long createComment(Long lostReportId, LostReportCommentCreateRequest request) {
         Member member = memberUtil.getLoggedInMember();
-        
+
         LostReport lostReport = lostReportRepository.findById(lostReportId)
                 .orElseThrow(() -> new LostReportException(LOST_REPORT_NOT_FOUND));
 
@@ -66,5 +70,22 @@ public class LostReportService {
 
         LostReportComment savedComment = lostReportCommentRepository.save(comment);
         return savedComment.getId();
+    }
+
+    @Transactional
+    public LostReportCommentsResponse getComments(Long lostReportId) {
+        lostReportRepository.findById(lostReportId)
+                .orElseThrow(() -> new LostReportException(LOST_REPORT_NOT_FOUND));
+
+        List<LostReportComment> comments = lostReportCommentRepository.findByLostReportIdOrderByCreatedAtAsc(lostReportId);
+
+        List<LostReportCommentResponse> commentResponses = comments.stream()
+                .map(LostReportCommentResponse::of)
+                .toList();
+
+        return new LostReportCommentsResponse(
+                comments.size(),
+                commentResponses
+        );
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
@@ -1,0 +1,39 @@
+package Hongik_SafeMap_Server.domain.lost_report.service;
+
+import Hongik_SafeMap_Server.domain.lost_report.domain.LostReport;
+import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequest;
+import Hongik_SafeMap_Server.domain.lost_report.repository.LostReportRepository;
+import Hongik_SafeMap_Server.domain.member.domain.Member;
+import Hongik_SafeMap_Server.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LostReportService {
+
+    private final LostReportRepository lostReportRepository;
+    private final MemberUtil memberUtil;
+
+    @Transactional
+    public Long create(LostReportCreateRequest request) {
+        Member member = memberUtil.getLoggedInMember();
+
+        LostReport lostReport = LostReport.builder()
+                .category(request.category())
+                .title(request.title())
+                .description(request.description())
+                .age(request.age())
+                .characteristic(request.characteristic())
+                .lastSeen(request.lastSeen())
+                .currentLocation(request.currentLocation())
+                .member(member)
+                .fileUrls(request.fileUrls())
+                .build();
+
+        LostReport savedReport = lostReportRepository.save(lostReport);
+        return savedReport.getId();
+    }
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
@@ -4,6 +4,7 @@ import Hongik_SafeMap_Server.domain.lost_report.domain.LostReport;
 import Hongik_SafeMap_Server.domain.lost_report.domain.LostReportComment;
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCommentCreateRequest;
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequest;
+import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportUpdateRequest;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportCommentResponse;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportCommentsResponse;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportResponse;
@@ -144,5 +145,35 @@ public class LostReportService {
         
         lostReport.softDelete();
         lostReportRepository.save(lostReport);
+    }
+
+    @Transactional
+    public LostReportResponse update(Long id, LostReportUpdateRequest request) {
+        Member member = memberUtil.getLoggedInMember();
+        
+        LostReport lostReport = lostReportRepository.findByIdAndNotDeleted(id)
+                .orElseThrow(() -> new LostReportException(LOST_REPORT_NOT_FOUND));
+        
+        // 작성자 본인인지 확인
+        if (!lostReport.getMember().getId().equals(member.getId())) {
+            throw new IllegalArgumentException("본인이 작성한 게시물만 수정할 수 있습니다");
+        }
+        
+        lostReport.update(
+                request.category(),
+                request.status(),
+                request.title(),
+                request.description(),
+                request.age(),
+                request.characteristic(),
+                request.lastSeen(),
+                request.currentLocation(),
+                request.fileUrls()
+        );
+        
+        LostReport updatedReport = lostReportRepository.save(lostReport);
+        long commentCount = lostReportCommentRepository.countByLostReportId(id);
+        
+        return LostReportResponse.of(updatedReport, commentCount);
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
@@ -2,12 +2,16 @@ package Hongik_SafeMap_Server.domain.lost_report.service;
 
 import Hongik_SafeMap_Server.domain.lost_report.domain.LostReport;
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequest;
+import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportResponse;
 import Hongik_SafeMap_Server.domain.lost_report.repository.LostReportRepository;
 import Hongik_SafeMap_Server.domain.member.domain.Member;
+import Hongik_SafeMap_Server.exception.LostReportException;
 import Hongik_SafeMap_Server.util.MemberUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static Hongik_SafeMap_Server.exception.ErrorMessage.LOST_REPORT_NOT_FOUND;
 
 @Service
 @Transactional(readOnly = true)
@@ -35,5 +39,11 @@ public class LostReportService {
 
         LostReport savedReport = lostReportRepository.save(lostReport);
         return savedReport.getId();
+    }
+
+    public LostReportResponse getById(Long id) {
+        LostReport lostReport = lostReportRepository.findById(id)
+                .orElseThrow(() -> new LostReportException(LOST_REPORT_NOT_FOUND));
+        return LostReportResponse.of(lostReport);
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
@@ -1,8 +1,11 @@
 package Hongik_SafeMap_Server.domain.lost_report.service;
 
 import Hongik_SafeMap_Server.domain.lost_report.domain.LostReport;
+import Hongik_SafeMap_Server.domain.lost_report.domain.LostReportComment;
+import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCommentCreateRequest;
 import Hongik_SafeMap_Server.domain.lost_report.dto.request.LostReportCreateRequest;
 import Hongik_SafeMap_Server.domain.lost_report.dto.response.LostReportResponse;
+import Hongik_SafeMap_Server.domain.lost_report.repository.LostReportCommentRepository;
 import Hongik_SafeMap_Server.domain.lost_report.repository.LostReportRepository;
 import Hongik_SafeMap_Server.domain.member.domain.Member;
 import Hongik_SafeMap_Server.exception.LostReportException;
@@ -19,6 +22,7 @@ import static Hongik_SafeMap_Server.exception.ErrorMessage.LOST_REPORT_NOT_FOUND
 public class LostReportService {
 
     private final LostReportRepository lostReportRepository;
+    private final LostReportCommentRepository lostReportCommentRepository;
     private final MemberUtil memberUtil;
 
     @Transactional
@@ -45,5 +49,22 @@ public class LostReportService {
         LostReport lostReport = lostReportRepository.findById(id)
                 .orElseThrow(() -> new LostReportException(LOST_REPORT_NOT_FOUND));
         return LostReportResponse.of(lostReport);
+    }
+
+    @Transactional
+    public Long createComment(Long lostReportId, LostReportCommentCreateRequest request) {
+        Member member = memberUtil.getLoggedInMember();
+        
+        LostReport lostReport = lostReportRepository.findById(lostReportId)
+                .orElseThrow(() -> new LostReportException(LOST_REPORT_NOT_FOUND));
+
+        LostReportComment comment = LostReportComment.builder()
+                .content(request.content())
+                .member(member)
+                .lostReport(lostReport)
+                .build();
+
+        LostReportComment savedComment = lostReportCommentRepository.save(comment);
+        return savedComment.getId();
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/lost_report/service/LostReportService.java
@@ -56,7 +56,7 @@ public class LostReportService {
     }
 
     public LostReportResponse getById(Long id) {
-        LostReport lostReport = lostReportRepository.findById(id)
+        LostReport lostReport = lostReportRepository.findByIdAndNotDeleted(id)
                 .orElseThrow(() -> new LostReportException(LOST_REPORT_NOT_FOUND));
 
         long commentCount = lostReportCommentRepository.countByLostReportId(id);
@@ -100,7 +100,7 @@ public class LostReportService {
     public Long createComment(Long lostReportId, LostReportCommentCreateRequest request) {
         Member member = memberUtil.getLoggedInMember();
 
-        LostReport lostReport = lostReportRepository.findById(lostReportId)
+        LostReport lostReport = lostReportRepository.findByIdAndNotDeleted(lostReportId)
                 .orElseThrow(() -> new LostReportException(LOST_REPORT_NOT_FOUND));
 
         LostReportComment comment = LostReportComment.builder()
@@ -115,7 +115,7 @@ public class LostReportService {
 
     @Transactional
     public LostReportCommentsResponse getComments(Long lostReportId) {
-        lostReportRepository.findById(lostReportId)
+        lostReportRepository.findByIdAndNotDeleted(lostReportId)
                 .orElseThrow(() -> new LostReportException(LOST_REPORT_NOT_FOUND));
 
         List<LostReportComment> comments = lostReportCommentRepository.findByLostReportIdOrderByCreatedAtAsc(lostReportId);
@@ -128,5 +128,21 @@ public class LostReportService {
                 comments.size(),
                 commentResponses
         );
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        Member member = memberUtil.getLoggedInMember();
+        
+        LostReport lostReport = lostReportRepository.findByIdAndNotDeleted(id)
+                .orElseThrow(() -> new LostReportException(LOST_REPORT_NOT_FOUND));
+        
+        // 작성자 본인인지 확인
+        if (!lostReport.getMember().getId().equals(member.getId())) {
+            throw new IllegalArgumentException("본인이 작성한 게시물만 삭제할 수 있습니다");
+        }
+        
+        lostReport.softDelete();
+        lostReportRepository.save(lostReport);
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/member/dto/request/SignUpRequest.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/member/dto/request/SignUpRequest.java
@@ -1,6 +1,7 @@
 package Hongik_SafeMap_Server.domain.member.dto.request;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -8,22 +9,28 @@ import jakarta.validation.constraints.Pattern;
 import static Hongik_SafeMap_Server.constant.RequestFormatConstant.PASSWORD_REGEX;
 import static Hongik_SafeMap_Server.exception.ErrorMessage.PASSWORD_INVALID_FORMAT;
 
-public record SignUpRequest(@NotBlank(message = "이름은 필수 입력값입니다.")
-                            @Pattern(regexp = "[가-힣]{1,6}$", message = "이름은 한글 6자 이하로 입력해주세요.")
-                            String name,
+public record SignUpRequest(
+        @Schema(description = "이름", example = "홍길동")
+        @NotBlank(message = "이름은 필수 입력값입니다.")
+        @Pattern(regexp = "[가-힣]{1,6}$", message = "이름은 한글 6자 이하로 입력해주세요.")
+        String name,
 
-                            @NotBlank(message = "이메일은 필수 입력값입니다.")
-                            @Email(message = "이메일 형식이 올바르지 않습니다.")
-                            String email,
+        @Schema(description = "이메일", example = "user@naver.com")
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
 
-                            @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-                            @Pattern(regexp = PASSWORD_REGEX, message = PASSWORD_INVALID_FORMAT)
-                            String password,
+        @Schema(description = "비밀번호", example = "safemap@1234")
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        @Pattern(regexp = PASSWORD_REGEX, message = PASSWORD_INVALID_FORMAT)
+        String password,
 
-                            @NotBlank(message = "비밀번호를 한 번 더 입력해주세요.")
-                            String passwordConfirm,
+        @Schema(description = "비밀번호 확인", example = "safemap@1234")
+        @NotBlank(message = "비밀번호를 한 번 더 입력해주세요.")
+        String passwordConfirm,
 
-                            @NotBlank(message = "휴대전화는 필수 입력값입니다.")
-                            @Pattern(regexp = "[0-9]{1,12}$", message = "전화번호는 11자리 이하로 입력해주세요.")
-                            String phone) {
+        @Schema(description = "전화번호", example = "01012341234")
+        @NotBlank(message = "휴대전화는 필수 입력값입니다.")
+        @Pattern(regexp = "[0-9]{1,12}$", message = "전화번호는 11자리 이하로 입력해주세요.")
+        String phone) {
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/global/GlobalExceptionHandler.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/global/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package Hongik_SafeMap_Server.global;
 
 import Hongik_SafeMap_Server.exception.AuthException;
 import Hongik_SafeMap_Server.exception.DisasterReportException;
+import Hongik_SafeMap_Server.exception.LostReportException;
 import Hongik_SafeMap_Server.exception.MemberException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -61,6 +62,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DisasterReportException.class)
     public ErrorResponse handleDisasterReportException(DisasterReportException ex) {
         log.info("exception.DisasterReportException: {}", ex.getMessage());
+
+        return ErrorResponse.create(
+                ex,
+                HttpStatus.NOT_FOUND,
+                ex.getMessage()
+        );
+    }
+
+    // LostReport 도메인 예외처리(404)
+    @ExceptionHandler(LostReportException.class)
+    public ErrorResponse handleLostReportException(LostReportException ex) {
+        log.info("exception.LostReportException: {}", ex.getMessage());
 
         return ErrorResponse.create(
                 ex,

--- a/core-api/src/main/java/Hongik_SafeMap_Server/global/dto/response/LostReportWithCommentCount.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/global/dto/response/LostReportWithCommentCount.java
@@ -1,0 +1,9 @@
+package Hongik_SafeMap_Server.global.dto.response;
+
+import Hongik_SafeMap_Server.domain.lost_report.domain.LostReport;
+
+public record LostReportWithCommentCount(
+        LostReport lostReport,
+        Long commentCount
+) {
+}


### PR DESCRIPTION
## 작업 내용
- 실종찾기 게시물 작성
- 실종찾기 게시물 조회
- 실종찾기 게시물 수정
- 실종찾기 게시물 삭제
- 실종찾기 게시물 댓글 작성
- 실종찾기 게시물 댓글 목록 조회
- 실종찾기 조회

## 특이 사항 (리뷰 시 참고할 내용)
- 게시물 삭제 시 게시물 soft delete(댓글은 보존하나 조회는 불가)
- 게시물 patch도 구현해야 할지 논의 필요

### 관련 이슈
close #26 