### PR TITLE
feat: 실시간 지도 재난 제보 로직 구현

### DIFF
--- a/common/src/main/java/Hongik_SafeMap_Server/exception/ErrorMessage.java
+++ b/common/src/main/java/Hongik_SafeMap_Server/exception/ErrorMessage.java
@@ -23,6 +23,9 @@ public class ErrorMessage {
     public static final String CANNOT_APPROVE_BLINDED_REPORT = "블라인드 처리된 제보는 승인할 수 없습니다.";
     public static final String CANNOT_APPROVE_FALSE_REPORT = "허위로 처리된 제보는 승인할 수 없습니다.";
 
+    // DisasterReportGroup
+    public static final String DISASTER_REPORT_GROUP_NOT_FOUND = "해당 id를 가진 그룹을 찾을 수 없습니다.";
+
     // LostReport
     public static final String LOST_REPORT_NOT_FOUND = "해당 id를 가진 실종신고를 찾을 수 없습니다.";
 

--- a/common/src/main/java/Hongik_SafeMap_Server/exception/ErrorMessage.java
+++ b/common/src/main/java/Hongik_SafeMap_Server/exception/ErrorMessage.java
@@ -20,6 +20,8 @@ public class ErrorMessage {
 
     // DisasterReport
     public static final String INVALID_DISASTER_REPORT = "해당 id를 가진 제보를 찾을 수 없습니다.";
+    public static final String CANNOT_APPROVE_BLINDED_REPORT = "블라인드 처리된 제보는 승인할 수 없습니다.";
+    public static final String CANNOT_APPROVE_FALSE_REPORT = "허위로 처리된 제보는 승인할 수 없습니다.";
 
     // LostReport
     public static final String LOST_REPORT_NOT_FOUND = "해당 id를 가진 실종신고를 찾을 수 없습니다.";

--- a/core-api/src/main/java/Hongik_SafeMap_Server/HongikSafeMapServerApplication.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/HongikSafeMapServerApplication.java
@@ -3,9 +3,11 @@ package Hongik_SafeMap_Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class HongikSafeMapServerApplication {
 
 	public static void main(String[] args) {

--- a/core-api/src/main/java/Hongik_SafeMap_Server/config/SwaggerConfig.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/config/SwaggerConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -28,6 +29,7 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
                 .security(java.util.List.of(securityRequirement))
+                .addServersItem(new Server().url("/").description("Default Server URL"))
                 .info(new Info()
                         .title("SafeMap Server API")
                         .description("SafeMap 서버 API")

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report/domain/DisasterReport.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report/domain/DisasterReport.java
@@ -1,6 +1,7 @@
 package Hongik_SafeMap_Server.domain.disaster_report.domain;
 
 import Hongik_SafeMap_Server.domain.common.BaseTimeEntity;
+import Hongik_SafeMap_Server.domain.disaster_report_group.domain.DisasterReportGroup;
 import Hongik_SafeMap_Server.domain.member.domain.Member;
 import Hongik_SafeMap_Server.vo.DisasterReportStatus;
 import Hongik_SafeMap_Server.vo.DisasterType;
@@ -63,6 +64,10 @@ public class DisasterReport extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "disaster_report_group_id")
+    private DisasterReportGroup group;
+
     @Builder
     private DisasterReport(
             DisasterType disasterType,
@@ -97,5 +102,9 @@ public class DisasterReport extends BaseTimeEntity {
 
     public void markFalse() {
         this.status = DisasterReportStatus.FALSE;
+    }
+
+    public void updateGroup(DisasterReportGroup group) {
+        this.group = group;
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report/repository/DisasterReportRepository.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report/repository/DisasterReportRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -40,18 +41,25 @@ public interface DisasterReportRepository extends JpaRepository<DisasterReport, 
     Page<DisasterReport> findByDisasterTypeInAndRiskLevelInOrderByCreatedAtDesc(List<DisasterType> disasterTypes, List<RiskLevel> riskLevels, Pageable pageable);
 
     @Query("""
-    select new Hongik_SafeMap_Server.domain.admin.member.dto.AdminMemberResponse(
-        m.id,
-        m.name,
-        m.email,
-        count(dr),
-        0,
-        m.isCredible
-    )
-    from Member m
-    left join DisasterReport dr on dr.member = m
-    where m.status = Hongik_SafeMap_Server.vo.MemberStatus.USER
-    group by m.id, m.name, m.email, m.isCredible
-""")
+                select new Hongik_SafeMap_Server.domain.admin.member.dto.AdminMemberResponse(
+                    m.id,
+                    m.name,
+                    m.email,
+                    count(dr),
+                    0,
+                    m.isCredible
+                )
+                from Member m
+                left join DisasterReport dr on dr.member = m
+                where m.status = Hongik_SafeMap_Server.vo.MemberStatus.USER
+                group by m.id, m.name, m.email, m.isCredible
+            """)
     List<AdminMemberResponse> findAdminMemberList();
+
+    // 그룹 아이디로 제보 목록 조회
+    List<DisasterReport> findByGroupId(@Param("groupId") Long groupId);
+
+    // 여러 그룹의 제보들 조회
+    @Query("SELECT dr FROM DisasterReport dr WHERE dr.group.id IN :groupIds")
+    List<DisasterReport> findByGroupIdIn(@Param("groupIds") List<Long> groupIds);
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report/service/DisasterReportService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report/service/DisasterReportService.java
@@ -6,8 +6,10 @@ import Hongik_SafeMap_Server.domain.disaster_report.dto.response.DisasterReportL
 import Hongik_SafeMap_Server.domain.disaster_report.dto.response.DisasterReportPageResponse;
 import Hongik_SafeMap_Server.domain.disaster_report.dto.response.DisasterReportResponse;
 import Hongik_SafeMap_Server.domain.disaster_report.repository.DisasterReportRepository;
+import Hongik_SafeMap_Server.domain.disaster_report_group.service.DisasterReportGroupService;
 import Hongik_SafeMap_Server.domain.member.domain.Member;
 import Hongik_SafeMap_Server.exception.DisasterReportException;
+import Hongik_SafeMap_Server.exception.ErrorMessage;
 import Hongik_SafeMap_Server.util.MemberUtil;
 import Hongik_SafeMap_Server.vo.DisasterReportStatus;
 import Hongik_SafeMap_Server.vo.DisasterType;
@@ -29,6 +31,7 @@ import static Hongik_SafeMap_Server.exception.ErrorMessage.INVALID_DISASTER_REPO
 @Transactional(readOnly = true)
 public class DisasterReportService {
     private final DisasterReportRepository disasterReportRepository;
+    private final DisasterReportGroupService groupService;
     private final MemberUtil memberUtil;
 
     // 긴급 제보 등록
@@ -48,7 +51,13 @@ public class DisasterReportService {
                 .member(member)
                 .build();
 
-        return disasterReportRepository.save(disasterReport).getId();
+        // 제보 저장
+        DisasterReport savedReport = disasterReportRepository.save(disasterReport);
+
+        // 그룹에 할당 (@TODO: 비동기 처리)
+        groupService.assignReportToGroup(savedReport);
+
+        return savedReport.getId();
     }
 
     // 제보 조회 (일반/관리자 공용)
@@ -62,7 +71,7 @@ public class DisasterReportService {
     // 전체 제보 목록 (관리자 전체 제보/지도)
     public DisasterReportPageResponse getAll(List<DisasterType> disasterTypes, List<RiskLevel> riskLevels, int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-        
+
         Page<DisasterReportListResponse> pageResult;
         if ((disasterTypes == null || disasterTypes.isEmpty()) && (riskLevels == null || riskLevels.isEmpty())) {
             // 필터 없음 - 전체 조회
@@ -81,9 +90,9 @@ public class DisasterReportService {
             pageResult = disasterReportRepository.findByRiskLevelInOrderByCreatedAtDesc(riskLevels, pageable)
                     .map(DisasterReportListResponse::of);
         }
-        
+
         List<DisasterReportListResponse> reports = pageResult.getContent();
-        
+
         return new DisasterReportPageResponse(
                 reports,
                 pageResult.getNumber(),
@@ -110,6 +119,14 @@ public class DisasterReportService {
         DisasterReport disasterReport = disasterReportRepository.findById(reportId)
                 .orElseThrow(() -> new DisasterReportException(INVALID_DISASTER_REPORT));
 
+        // 이미 처리된 제보인지 검증(@TODO: 변경 가능하게 수정 - 통계 업데이트 문제 때문에 임시 에러 처리)
+        if (disasterReport.getStatus() == DisasterReportStatus.BLINDED) {
+            throw new DisasterReportException(ErrorMessage.CANNOT_APPROVE_BLINDED_REPORT);
+        }
+        if (disasterReport.getStatus() == DisasterReportStatus.FALSE) {
+            throw new DisasterReportException(ErrorMessage.CANNOT_APPROVE_FALSE_REPORT);
+        }
+
         disasterReport.approve();
     }
 
@@ -119,7 +136,19 @@ public class DisasterReportService {
         DisasterReport disasterReport = disasterReportRepository.findById(reportId)
                 .orElseThrow(() -> new DisasterReportException(INVALID_DISASTER_REPORT));
 
+        Long groupId = null;
+        // 그룹에서 제거 (블라인드된 제보는 그룹 통계에서 제외)
+        if (disasterReport.getGroup() != null) {
+            groupId = disasterReport.getGroup().getId();
+            disasterReport.getGroup().removeReport(disasterReport);
+        }
+
         disasterReport.blind();
+
+        // 그룹 통계 재계산
+        if (groupId != null) {
+            groupService.calculateGroupStatistics(groupId);
+        }
     }
 
     // 관리자 제보 허위 처리
@@ -128,6 +157,19 @@ public class DisasterReportService {
         DisasterReport disasterReport = disasterReportRepository.findById(reportId)
                 .orElseThrow(() -> new DisasterReportException(INVALID_DISASTER_REPORT));
 
+        Long groupId = null;
+        // 그룹에서 제거 (허위 제보는 그룹 통계에서 제외)
+        if (disasterReport.getGroup() != null) {
+            groupId = disasterReport.getGroup().getId();
+            disasterReport.getGroup().removeReport(disasterReport);
+        }
+
         disasterReport.markFalse();
+
+        // 그룹 통계 재계산
+        if (groupId != null) {
+            groupService.calculateGroupStatistics(groupId);
+        }
     }
+
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/controller/DisasterReportGroupController.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/controller/DisasterReportGroupController.java
@@ -1,0 +1,38 @@
+package Hongik_SafeMap_Server.domain.disaster_report_group.controller;
+
+import Hongik_SafeMap_Server.domain.disaster_report_group.dto.response.GroupedDisasterReportResponse;
+import Hongik_SafeMap_Server.domain.disaster_report_group.service.DisasterReportGroupService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/disaster-reports")
+@Tag(name = "재난 제보 그룹 조회")
+public class DisasterReportGroupController {
+    private final DisasterReportGroupService disasterReportGroupService;
+
+    @Operation(summary = "재난 제보 클러스터 조회", description = """
+            실시간 지도(마지막 업데이트 24시간 이내)에서 클러스터링 된 재난 제보를 조회하기 위해 사용할 수 있습니다.
+            isActive 파라미터를 false로 설정하면 전체 재난 제보를 조회할 수 있습니다.
+            사용자 위치로부터 반경 몇 미터 내의 재난 제보를 조회할지 설정해서 조회할 수 있습니다.
+            사용자 위치 정보를 담지 않으면 클러스터링된 전체 지도 목록를 조회할 수 있습니다.
+            재난 제보 유형별, 위치별(500m)로 클러스터링된 그룹입니다.
+            """)
+    @GetMapping("/grouped")
+    public ResponseEntity<List<GroupedDisasterReportResponse>> getGroupedReports(
+            @RequestParam(name = "latitude", required = false) Double latitude,
+            @RequestParam(name = "longitude", required = false) Double longitude,
+            @RequestParam(name = "radiusMeters", defaultValue = "10000") int radiusMeters,
+            @RequestParam(name = "isActive", defaultValue = "true", required = false) Boolean isActive) {
+        return ResponseEntity.ok(disasterReportGroupService.getGroupedReports(latitude, longitude, radiusMeters, isActive));
+    }
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/controller/DisasterReportGroupController.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/controller/DisasterReportGroupController.java
@@ -1,15 +1,13 @@
 package Hongik_SafeMap_Server.domain.disaster_report_group.controller;
 
+import Hongik_SafeMap_Server.domain.disaster_report_group.dto.response.GroupDetailResponse;
 import Hongik_SafeMap_Server.domain.disaster_report_group.dto.response.GroupedDisasterReportResponse;
 import Hongik_SafeMap_Server.domain.disaster_report_group.service.DisasterReportGroupService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -34,5 +32,11 @@ public class DisasterReportGroupController {
             @RequestParam(name = "radiusMeters", defaultValue = "10000") int radiusMeters,
             @RequestParam(name = "isActive", defaultValue = "true", required = false) Boolean isActive) {
         return ResponseEntity.ok(disasterReportGroupService.getGroupedReports(latitude, longitude, radiusMeters, isActive));
+    }
+
+    @Operation(summary = "재난 제보 그룹 상세 조회", description = "특정 그룹의 통계 정보와 속한 재난 제보 목록을 함께 조회합니다.")
+    @GetMapping("/grouped/{groupId}")
+    public ResponseEntity<GroupDetailResponse> getGroupDetail(@PathVariable Long groupId) {
+        return ResponseEntity.ok(disasterReportGroupService.getGroupDetail(groupId));
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/domain/DisasterReportGroup.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/domain/DisasterReportGroup.java
@@ -1,12 +1,11 @@
 package Hongik_SafeMap_Server.domain.disaster_report_group.domain;
 
 import Hongik_SafeMap_Server.domain.disaster_report.domain.DisasterReport;
+import Hongik_SafeMap_Server.util.DistanceUtil;
 import Hongik_SafeMap_Server.vo.DisasterType;
 import Hongik_SafeMap_Server.vo.RiskLevel;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -50,13 +49,21 @@ public class DisasterReportGroup {
     @Column(nullable = false)
     private Boolean isActive;
 
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    /**
+     * 첫 번째 제보로부터 새 그룹 생성
+     */
+    public static DisasterReportGroup createFromFirstReport(DisasterReport report) {
+        return DisasterReportGroup.builder()
+                .disasterType(report.getDisasterType())
+                .centerLatitude(report.getLatitude())
+                .centerLongitude(report.getLongitude())
+                .earliestReportTime(report.getCreatedAt())
+                .latestReportTime(report.getCreatedAt())
+                .reportCount(1)
+                .latestRiskLevel(report.getRiskLevel())
+                .isActive(true)
+                .build();
+    }
 
     // 새로운 제보 추가
     public void addReport(DisasterReport report) {
@@ -97,7 +104,7 @@ public class DisasterReportGroup {
         }
 
         // 거리 확인 (위도/경도 기반)
-        double distance = calculateDistance(this.centerLatitude, this.centerLongitude,
+        double distance = DistanceUtil.calculateDistance(this.centerLatitude, this.centerLongitude,
                 report.getLatitude(), report.getLongitude());
         if (distance > maxDistanceM) {
             return false;
@@ -110,15 +117,4 @@ public class DisasterReportGroup {
         return hoursDiff < maxTimeSpanHours; // 정확히 maxTimeSpanHours 차이나면 기존 재난 제보에 추가 안함
     }
 
-    // 두 좌표 간 거리 계산
-    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
-        final double EARTH_RADIUS = 6371; // 지구 반지름 (km)
-        double latDistance = Math.toRadians(lat2 - lat1);
-        double lngDistance = Math.toRadians(lon2 - lon1);
-        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
-                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
-                * Math.sin(lngDistance / 2) * Math.sin(lngDistance / 2);
-        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        return EARTH_RADIUS * c * 1000; // 미터(m)
-    }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/domain/DisasterReportGroup.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/domain/DisasterReportGroup.java
@@ -47,7 +47,7 @@ public class DisasterReportGroup {
     private RiskLevel latestRiskLevel;
 
     @Column(nullable = false)
-    private Boolean isActive;
+    private boolean isActive;
 
     /**
      * 첫 번째 제보로부터 새 그룹 생성

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/domain/DisasterReportGroup.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/domain/DisasterReportGroup.java
@@ -1,0 +1,124 @@
+package Hongik_SafeMap_Server.domain.disaster_report_group.domain;
+
+import Hongik_SafeMap_Server.domain.disaster_report.domain.DisasterReport;
+import Hongik_SafeMap_Server.vo.DisasterType;
+import Hongik_SafeMap_Server.vo.RiskLevel;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "disaster_report_groups")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
+public class DisasterReportGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DisasterType disasterType;
+
+    @Column(nullable = false)
+    private Double centerLatitude;
+
+    @Column(nullable = false)
+    private Double centerLongitude;
+
+    @Column(nullable = false)
+    private LocalDateTime earliestReportTime;
+
+    @Column(nullable = false)
+    private LocalDateTime latestReportTime;
+
+    @Column(nullable = false)
+    private int reportCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RiskLevel latestRiskLevel;
+
+    @Column(nullable = false)
+    private Boolean isActive;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    // 새로운 제보 추가
+    public void addReport(DisasterReport report) {
+        report.updateGroup(this);
+    }
+
+    // 제보 제거시 그룹 참조 해제만 수행 (통계는 Service에서 별도 관리)
+    public void removeReport(DisasterReport report) {
+        report.updateGroup(null);
+    }
+
+    // 그룹 비활성화
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    // 그룹 통계 업데이트
+    public void updateStatistics(double centerLat, double centerLng, LocalDateTime earliestTime,
+                                 LocalDateTime latestTime, int reportCount, RiskLevel latestRisk, boolean isActive) {
+        this.centerLatitude = centerLat;
+        this.centerLongitude = centerLng;
+        this.earliestReportTime = earliestTime;
+        this.latestReportTime = latestTime;
+        this.reportCount = reportCount;
+        this.latestRiskLevel = latestRisk;
+        this.isActive = isActive;
+    }
+
+    // 그룹이 새로운 제보와 매칭되는지 확인
+    public boolean canAcceptReport(DisasterReport report, int maxDistanceM, int maxTimeSpanHours) {
+        if (!this.isActive) {
+            return false;
+        }
+
+        // 재난 타입 일치 확인
+        if (!this.disasterType.equals(report.getDisasterType())) {
+            return false;
+        }
+
+        // 거리 확인 (위도/경도 기반)
+        double distance = calculateDistance(this.centerLatitude, this.centerLongitude,
+                report.getLatitude(), report.getLongitude());
+        if (distance > maxDistanceM) {
+            return false;
+        }
+
+        // 시간 범위 확인
+        LocalDateTime reportTime = report.getCreatedAt();
+        long hoursDiff = java.time.Duration.between(this.latestReportTime, reportTime).toHours(); // 내림(24시간 30분 -> 24시간)
+
+        return hoursDiff < maxTimeSpanHours; // 정확히 maxTimeSpanHours 차이나면 기존 재난 제보에 추가 안함
+    }
+
+    // 두 좌표 간 거리 계산
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        final double EARTH_RADIUS = 6371; // 지구 반지름 (km)
+        double latDistance = Math.toRadians(lat2 - lat1);
+        double lngDistance = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(lngDistance / 2) * Math.sin(lngDistance / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return EARTH_RADIUS * c * 1000; // 미터(m)
+    }
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/dto/response/GroupDetailResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/dto/response/GroupDetailResponse.java
@@ -1,0 +1,29 @@
+package Hongik_SafeMap_Server.domain.disaster_report_group.dto.response;
+
+import Hongik_SafeMap_Server.domain.disaster_report.dto.response.DisasterReportListResponse;
+import Hongik_SafeMap_Server.vo.DisasterType;
+import Hongik_SafeMap_Server.vo.RiskLevel;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GroupDetailResponse(
+        Long groupId,
+        DisasterType disasterType,
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        Double centerLatitude,
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        Double centerLongitude,
+        LocalDateTime earliestReportTime,
+        LocalDateTime latestReportTime,
+        int reportCount,
+        RiskLevel latestRiskLevel,
+        boolean isActive,
+        List<DisasterReportListResponse> reports
+) {
+    public GroupDetailResponse {
+        centerLatitude = centerLatitude != null ? Math.round(centerLatitude * 1000000.0) / 1000000.0 : null;
+        centerLongitude = centerLongitude != null ? Math.round(centerLongitude * 1000000.0) / 1000000.0 : null;
+    }
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/dto/response/GroupedDisasterReportResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/dto/response/GroupedDisasterReportResponse.java
@@ -1,0 +1,19 @@
+package Hongik_SafeMap_Server.domain.disaster_report_group.dto.response;
+
+import Hongik_SafeMap_Server.vo.DisasterType;
+import Hongik_SafeMap_Server.vo.RiskLevel;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GroupedDisasterReportResponse(
+        DisasterType disasterType,
+        Double centerLatitude,
+        Double centerLongitude,
+        LocalDateTime earliestReportTime,
+        LocalDateTime latestReportTime,
+        int reportCount,
+        RiskLevel latestRiskLevel,
+        List<Long> reportIds
+) {
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/dto/response/GroupedDisasterReportResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/dto/response/GroupedDisasterReportResponse.java
@@ -2,18 +2,24 @@ package Hongik_SafeMap_Server.domain.disaster_report_group.dto.response;
 
 import Hongik_SafeMap_Server.vo.DisasterType;
 import Hongik_SafeMap_Server.vo.RiskLevel;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record GroupedDisasterReportResponse(
+        Long id,
         DisasterType disasterType,
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
         Double centerLatitude,
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
         Double centerLongitude,
         LocalDateTime earliestReportTime,
         LocalDateTime latestReportTime,
         int reportCount,
-        RiskLevel latestRiskLevel,
-        List<Long> reportIds
+        RiskLevel latestRiskLevel
 ) {
+    public GroupedDisasterReportResponse {
+        centerLatitude = centerLatitude != null ? Math.round(centerLatitude * 1000000.0) / 1000000.0 : null;
+        centerLongitude = centerLongitude != null ? Math.round(centerLongitude * 1000000.0) / 1000000.0 : null;
+    }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/repository/DisasterReportGroupRepository.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/repository/DisasterReportGroupRepository.java
@@ -1,0 +1,43 @@
+package Hongik_SafeMap_Server.domain.disaster_report_group.repository;
+
+import Hongik_SafeMap_Server.domain.disaster_report_group.domain.DisasterReportGroup;
+import Hongik_SafeMap_Server.vo.DisasterType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface DisasterReportGroupRepository extends JpaRepository<DisasterReportGroup, Long> {
+
+    // 활성 상태인 그룹들 조회
+    List<DisasterReportGroup> findByIsActiveTrueOrderByLatestReportTimeDesc();
+
+    // 특정 재난 타입에서 활성 상태인 그룹 찾기 (새로운 제보가 들어왔을 때 매칭용)
+    @Query("SELECT drg FROM DisasterReportGroup drg " +
+            "WHERE drg.isActive = true " +
+            "AND drg.disasterType = :disasterType " +
+            "ORDER BY drg.latestReportTime DESC")
+    List<DisasterReportGroup> findActiveGroupsForMatching(
+            @Param("disasterType") DisasterType disasterType);
+
+    // 특정 시간 이전에 마지막 업데이트된 그룹들 (비활성화 대상)
+    @Query("SELECT drg FROM DisasterReportGroup drg " +
+            "WHERE drg.isActive = true " +
+            "AND drg.latestReportTime < :cutoffTime")
+    List<DisasterReportGroup> findGroupsToDeactivate(@Param("cutoffTime") LocalDateTime cutoffTime);
+
+    // 활성 그룹들의 요약 정보 조회 (실시간 지도용)
+    @Query("SELECT drg FROM DisasterReportGroup drg " +
+            "WHERE drg.isActive = true " +
+            "AND drg.reportCount > 0 " +
+            "ORDER BY drg.reportCount DESC, drg.latestReportTime DESC")
+    List<DisasterReportGroup> findActiveGroupsSummary();
+
+    // 모든 그룹들의 요약 정보 조회 (활성/비활성 포함)
+    @Query("SELECT drg FROM DisasterReportGroup drg " +
+            "WHERE drg.reportCount > 0 " +
+            "ORDER BY drg.reportCount DESC, drg.latestReportTime DESC")
+    List<DisasterReportGroup> findAllGroupsSummary();
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/service/DisasterReportGroupService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/service/DisasterReportGroupService.java
@@ -1,10 +1,13 @@
 package Hongik_SafeMap_Server.domain.disaster_report_group.service;
 
 import Hongik_SafeMap_Server.domain.disaster_report.domain.DisasterReport;
+import Hongik_SafeMap_Server.domain.disaster_report.dto.response.DisasterReportListResponse;
 import Hongik_SafeMap_Server.domain.disaster_report.repository.DisasterReportRepository;
 import Hongik_SafeMap_Server.domain.disaster_report_group.domain.DisasterReportGroup;
+import Hongik_SafeMap_Server.domain.disaster_report_group.dto.response.GroupDetailResponse;
 import Hongik_SafeMap_Server.domain.disaster_report_group.dto.response.GroupedDisasterReportResponse;
 import Hongik_SafeMap_Server.domain.disaster_report_group.repository.DisasterReportGroupRepository;
+import Hongik_SafeMap_Server.exception.ErrorMessage;
 import Hongik_SafeMap_Server.util.DistanceUtil;
 import Hongik_SafeMap_Server.vo.RiskLevel;
 import lombok.RequiredArgsConstructor;
@@ -205,5 +208,28 @@ public class DisasterReportGroupService {
                         group.getLatestRiskLevel()
                 ))
                 .toList();
+    }
+
+    public GroupDetailResponse getGroupDetail(Long groupId) {
+        DisasterReportGroup group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorMessage.DISASTER_REPORT_GROUP_NOT_FOUND));
+
+        List<DisasterReport> reports = reportRepository.findByGroupId(groupId);
+        List<DisasterReportListResponse> reportResponses = reports.stream()
+                .map(DisasterReportListResponse::of)
+                .toList();
+
+        return new GroupDetailResponse(
+                group.getId(),
+                group.getDisasterType(),
+                group.getCenterLatitude(),
+                group.getCenterLongitude(),
+                group.getEarliestReportTime(),
+                group.getLatestReportTime(),
+                group.getReportCount(),
+                group.getLatestRiskLevel(),
+                group.getIsActive(),
+                reportResponses
+        );
     }
 }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/service/DisasterReportGroupService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/service/DisasterReportGroupService.java
@@ -1,0 +1,213 @@
+package Hongik_SafeMap_Server.domain.disaster_report_group.service;
+
+import Hongik_SafeMap_Server.domain.disaster_report.domain.DisasterReport;
+import Hongik_SafeMap_Server.domain.disaster_report.repository.DisasterReportRepository;
+import Hongik_SafeMap_Server.domain.disaster_report_group.domain.DisasterReportGroup;
+import Hongik_SafeMap_Server.domain.disaster_report_group.dto.response.GroupedDisasterReportResponse;
+import Hongik_SafeMap_Server.domain.disaster_report_group.repository.DisasterReportGroupRepository;
+import Hongik_SafeMap_Server.util.DistanceUtil;
+import Hongik_SafeMap_Server.vo.RiskLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DisasterReportGroupService {
+
+    // 그룹핑 기준 설정
+    private static final int MAX_DISTANCE_M = 500; // 500m 이내
+    private static final int MAX_TIME_SPAN_HOURS = 24; // 24시간 이내 (새 제보가 24시간 이후에 들어오면 새로운 그룹에 추가)
+    private static final int GROUP_DEACTIVATE_HOURS = 24; // 마지막 제보로부터 24시간 후 비활성화(비활성화 되면 그룹이 지도에서 사라짐)
+    private final DisasterReportGroupRepository groupRepository;
+    private final DisasterReportRepository reportRepository;
+
+    /**
+     * 새로운 제보를 기존 그룹에 할당하거나 새 그룹을 생성
+     */
+    @Transactional
+    public DisasterReportGroup assignReportToGroup(DisasterReport report) {
+        log.info("제보 그룹핑 시작: reportId={}, type={}, location={}",
+                report.getId(), report.getDisasterType(), report.getAddress());
+
+        // 1. 기존 그룹에서 매칭 가능한 그룹 찾기 (거리, 시간 기반)
+        Optional<DisasterReportGroup> matchingGroup = findMatchingGroup(report);
+
+        if (matchingGroup.isPresent()) {
+            // 2-1. 기존 그룹에 추가 (증분 통계 업데이트)
+            DisasterReportGroup group = matchingGroup.get();
+
+            // 제보 추가
+            group.addReport(report);
+
+            // 증분 통계 계산
+            int newCount = group.getReportCount() + 1;
+            double newCenterLat = (group.getCenterLatitude() * group.getReportCount() + report.getLatitude()) / newCount;
+            double newCenterLng = (group.getCenterLongitude() * group.getReportCount() + report.getLongitude()) / newCount;
+            LocalDateTime newLatestTime = report.getCreatedAt();
+            RiskLevel newLatestRisk = report.getRiskLevel();
+
+            // 통계 업데이트 (증분)
+            group.updateStatistics(newCenterLat, newCenterLng, group.getEarliestReportTime(),
+                    newLatestTime, newCount, newLatestRisk, true);
+            DisasterReportGroup savedGroup = groupRepository.save(group);
+
+            log.info("기존 그룹에 제보 추가: groupId={}, reportId={}", group.getId(), report.getId());
+            return savedGroup;
+        } else {
+            // 2-2. 새 그룹 생성
+            DisasterReportGroup newGroup = createNewGroup(report);
+            newGroup.addReport(report);  // 그룹-제보 관계 설정
+            DisasterReportGroup savedGroup = groupRepository.save(newGroup);
+
+            log.info("새 그룹 생성: groupId={}, reportId={}", savedGroup.getId(), report.getId());
+            return savedGroup;
+        }
+    }
+
+    /**
+     * 새로운 제보와 매칭되는 활성 그룹 찾기
+     */
+    private Optional<DisasterReportGroup> findMatchingGroup(DisasterReport report) {
+        List<DisasterReportGroup> candidateGroups = groupRepository
+                .findActiveGroupsForMatching(report.getDisasterType());
+
+        return candidateGroups.stream()
+                .filter(group -> group.canAcceptReport(report, MAX_DISTANCE_M, MAX_TIME_SPAN_HOURS))
+                .findFirst();
+    }
+
+    /**
+     * 새로운 그룹 생성 (첫 번째 제보 기반으로 초기화)
+     */
+    private DisasterReportGroup createNewGroup(DisasterReport report) {
+        return DisasterReportGroup.createFromFirstReport(report);
+    }
+
+    /**
+     * 오래된 그룹들 비활성화 (스케줄링용)
+     *
+     * @Scheduled 어노테이션과 함께 사용하여 주기적으로 오래된 그룹들을 비활성화
+     * 예시: @Scheduled(fixedRate = 3600000) // 1시간마다 실행
+     * 목적:
+     * - 24시간 이상 업데이트되지 않은 그룹을 비활성화
+     * - 지도에서 오래된 재난 정보가 계속 표시되는 것을 방지
+     * - 데이터베이스 성능 최적화 (활성 그룹만 조회)
+     */
+    @Transactional
+    public void deactivateOldGroups() {
+        LocalDateTime cutoffTime = LocalDateTime.now().minusHours(GROUP_DEACTIVATE_HOURS);
+        List<DisasterReportGroup> oldGroups = groupRepository.findGroupsToDeactivate(cutoffTime);
+
+        oldGroups.forEach(DisasterReportGroup::deactivate);
+        groupRepository.saveAll(oldGroups);
+
+        log.info("오래된 그룹 비활성화 완료: {} 개 그룹", oldGroups.size());
+    }
+
+    /**
+     * 활성 그룹 목록 조회 (지도 표시용)
+     */
+    public List<DisasterReportGroup> getActiveGroups() {
+        return groupRepository.findActiveGroupsSummary();
+    }
+
+    /**
+     * 그룹 목록 조회 (활성 여부에 따라)
+     */
+    public List<DisasterReportGroup> getGroups(boolean activeOnly) {
+        return activeOnly ? groupRepository.findActiveGroupsSummary() : groupRepository.findAllGroupsSummary();
+    }
+
+
+    /**
+     * 그룹 통계 업데이트 (처음부터 재계산, 제보 제거 후)
+     */
+    @Transactional
+    public void calculateGroupStatistics(Long groupId) {
+        DisasterReportGroup group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("그룹을 찾을 수 없습니다: " + groupId));
+
+        List<DisasterReport> approvedReports = reportRepository.findByGroupId(groupId);
+
+        if (approvedReports.isEmpty()) {
+            groupRepository.delete(group);
+            return;
+        }
+
+        // 통계 재계산
+        double avgLat = approvedReports.stream().mapToDouble(DisasterReport::getLatitude).average().orElse(0.0);
+        double avgLng = approvedReports.stream().mapToDouble(DisasterReport::getLongitude).average().orElse(0.0);
+
+        LocalDateTime earliestTime = approvedReports.stream()
+                .map(DisasterReport::getCreatedAt)
+                .min(LocalDateTime::compareTo)
+                .orElse(LocalDateTime.now());
+
+        LocalDateTime latestTime = approvedReports.stream()
+                .map(DisasterReport::getCreatedAt)
+                .max(LocalDateTime::compareTo)
+                .orElse(LocalDateTime.now());
+
+        RiskLevel latestRisk = approvedReports.stream()
+                .max(Comparator.comparing(DisasterReport::getCreatedAt))
+                .map(DisasterReport::getRiskLevel)
+                .orElse(RiskLevel.LOW);
+
+        long hoursDiff = java.time.Duration.between(latestTime, LocalDateTime.now()).toHours();
+        boolean isActive = hoursDiff < GROUP_DEACTIVATE_HOURS;
+
+        group.updateStatistics(avgLat, avgLng, earliestTime, latestTime, approvedReports.size(), latestRisk, isActive);
+    }
+
+    // 지역별/재난유형별 그룹화 조회 (지도 클러스터링용) - 그룹 테이블 기반
+    @Transactional(readOnly = true)
+    public List<GroupedDisasterReportResponse> getGroupedReports(Double userLatitude, Double userLongitude, int radiusMeters, Boolean isActive) {
+        List<DisasterReportGroup> groups = getGroups(isActive);
+
+        // 사용자 위치가 제공된 경우 거리 필터링
+        if (userLatitude != null && userLongitude != null) {
+            groups = groups.stream()
+                    .filter(group -> DistanceUtil.isWithinRadius(
+                            userLatitude, userLongitude,
+                            group.getCenterLatitude(), group.getCenterLongitude(),
+                            radiusMeters))
+                    .toList();
+        }
+
+        // 모든 그룹 ID를 수집
+        List<Long> groupIds = groups.stream()
+                .map(DisasterReportGroup::getId)
+                .toList();
+
+        List<DisasterReport> allReports = reportRepository.findByGroupIdIn(groupIds);
+
+        // 그룹별로 제보들을 분류
+        Map<Long, List<DisasterReport>> reportsByGroup = allReports.stream()
+                .collect(Collectors.groupingBy(report -> report.getGroup().getId()));
+
+        // 각 그룹을 응답 객체로 변환
+        return groups.stream()
+                .map(group -> new GroupedDisasterReportResponse(
+                        group.getId(),
+                        group.getDisasterType(),
+                        group.getCenterLatitude(),
+                        group.getCenterLongitude(),
+                        group.getEarliestReportTime(),
+                        group.getLatestReportTime(),
+                        group.getReportCount(),
+                        group.getLatestRiskLevel()
+                ))
+                .toList();
+    }
+}

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/service/DisasterReportGroupService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/service/DisasterReportGroupService.java
@@ -228,7 +228,7 @@ public class DisasterReportGroupService {
                 group.getLatestReportTime(),
                 group.getReportCount(),
                 group.getLatestRiskLevel(),
-                group.getIsActive(),
+                group.isActive(),
                 reportResponses
         );
     }

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/service/DisasterReportGroupService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report_group/service/DisasterReportGroupService.java
@@ -9,6 +9,7 @@ import Hongik_SafeMap_Server.util.DistanceUtil;
 import Hongik_SafeMap_Server.vo.RiskLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -95,15 +96,10 @@ public class DisasterReportGroupService {
     }
 
     /**
-     * 오래된 그룹들 비활성화 (스케줄링용)
-     *
-     * @Scheduled 어노테이션과 함께 사용하여 주기적으로 오래된 그룹들을 비활성화
-     * 예시: @Scheduled(fixedRate = 3600000) // 1시간마다 실행
-     * 목적:
-     * - 24시간 이상 업데이트되지 않은 그룹을 비활성화
-     * - 지도에서 오래된 재난 정보가 계속 표시되는 것을 방지
-     * - 데이터베이스 성능 최적화 (활성 그룹만 조회)
+     * 오래된 그룹들 비활성화 (스케줄링)
+     * 1시간마다 실행하여 24시간 이상 업데이트되지 않은 그룹을 비활성화
      */
+    @Scheduled(fixedRate = 3600000) // 1시간마다 실행 (3600000ms = 1시간)
     @Transactional
     public void deactivateOldGroups() {
         LocalDateTime cutoffTime = LocalDateTime.now().minusHours(GROUP_DEACTIVATE_HOURS);

--- a/core-api/src/main/java/Hongik_SafeMap_Server/util/DistanceUtil.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/util/DistanceUtil.java
@@ -1,0 +1,27 @@
+package Hongik_SafeMap_Server.util;
+
+public class DistanceUtil {
+
+    private static final double EARTH_RADIUS_M = 6371000;
+
+    // Haversine 공식을 사용하여 두 지점 간의 거리를 미터 단위로 계산
+    public static double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        double lat1Rad = Math.toRadians(lat1);
+        double lat2Rad = Math.toRadians(lat2);
+        double deltaLat = Math.toRadians(lat2 - lat1);
+        double deltaLon = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+                Math.cos(lat1Rad) * Math.cos(lat2Rad) *
+                        Math.sin(deltaLon / 2) * Math.sin(deltaLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return EARTH_RADIUS_M * c;
+    }
+
+    // 주어진 반경 내에 위치가 있는지 확인
+    public static boolean isWithinRadius(double lat1, double lon1, double lat2, double lon2, double radiusMeters) {
+        return calculateDistance(lat1, lon1, lat2, lon2) <= radiusMeters;
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 실시간 재난 제보 그룹(재난 유형, 시간별, 위치별로 그룹화) 조회
- 제보 등록/블라인드 시 재난 제보 그룹으로 분류 및 재난 그룹 통계 업데이트
  - 새로운 그룹에 제보 추가 시 해당 값을 그대로 그룹 통계로 사용(24시간 이내에 업데이트 된 500m 이내 해당 재난 유형의 그룹이 없을 경우)
  - 이전에 존재하던 그룹에 제보 추가 시 증분 계산
  - 블라인드 시 전체 재계산
- 배포 서버 swagger cors 에러로 default server url 지정

## 특이 사항 (리뷰 시 참고할 내용)
- 실시간: 24시간 이내
- 1시간마다 그룹 비활성화 스케줄링

### 관련 이슈
close #33 