### PR TITLE
fix: 관리자 권한 오류 해결

### DIFF
--- a/common/src/main/java/Hongik_SafeMap_Server/vo/MemberStatus.java
+++ b/common/src/main/java/Hongik_SafeMap_Server/vo/MemberStatus.java
@@ -1,6 +1,5 @@
 package Hongik_SafeMap_Server.vo;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,6 +9,5 @@ public enum MemberStatus {
     USER("일반"),
     ADMIN("관리자");
 
-    @JsonValue
     private final String description;
 }


### PR DESCRIPTION
## 작업 내용
- @JsonValue 삭제
  - @JsonValue로 인해 jwt 토큰에 'ROLE_관리자'로 저장되어 403 에러 발생

## 특이 사항 (리뷰 시 참고할 내용)
-

### 관련 이슈
close #52 