### PR TITLE
feat: 신뢰도 의심 계산 및 필드 추가

### DIFF
--- a/common/src/main/java/Hongik_SafeMap_Server/vo/DisasterReportStatus.java
+++ b/common/src/main/java/Hongik_SafeMap_Server/vo/DisasterReportStatus.java
@@ -10,7 +10,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum DisasterReportStatus implements EnumUtil.DescriptionProvider {
     PENDING("검토대기"),
-    VERIFIED("검증됨"),
     SUSPICIOUS("AI 신뢰도 의심"),
     APPROVED("승인"),
     BLINDED("블라인드");

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/admin/dashboard/dto/AdminDashboardResponse.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/admin/dashboard/dto/AdminDashboardResponse.java
@@ -12,8 +12,8 @@ public record AdminDashboardResponse(
         long totalReports,
         long falseReports,
         long totalUsers,
-        long suspiciousReports,
         long blindedReports,
+        long suspiciousReports,
         long credibleUsers,
         List<RecentReport> recentReports
 ) {

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/admin/dashboard/service/AdminDashboardService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/admin/dashboard/service/AdminDashboardService.java
@@ -21,7 +21,7 @@ public class AdminDashboardService {
         long pendingReports = disasterReportRepository.countByStatus(DisasterReportStatus.PENDING);
         long totalUsers = memberRepository.count();
         long blindedReports = disasterReportRepository.countByStatus(DisasterReportStatus.BLINDED);
-        long suspiciousReports = 0L; // @TODO: 신뢰도 의심
+        long suspiciousReports = disasterReportRepository.countByStatus(DisasterReportStatus.SUSPICIOUS);
         long credibleUsers = memberRepository.countByIsCredibleTrueAndStatus(MemberStatus.USER);
 
         List<AdminDashboardResponse.RecentReport> recentReports = disasterReportRepository.findTop4ByOrderByCreatedAtDesc()

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report/service/DisasterReportService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report/service/DisasterReportService.java
@@ -221,8 +221,8 @@ public class DisasterReportService {
     }
 
     private DisasterReportStatus resolveFinalStatus(DisasterReportStatus current, AiAnalyzeResponse aiResult) {
-        if (current == DisasterReportStatus.BLINDED) {
-            return DisasterReportStatus.BLINDED;
+        if (current == DisasterReportStatus.BLINDED || current == DisasterReportStatus.APPROVED) {
+            return current;
         }
         if (aiResult.trustScore() != null && aiResult.trustScore() <= 75) {
             return DisasterReportStatus.SUSPICIOUS;

--- a/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report/service/DisasterReportService.java
+++ b/core-api/src/main/java/Hongik_SafeMap_Server/domain/disaster_report/service/DisasterReportService.java
@@ -220,6 +220,16 @@ public class DisasterReportService {
         accusationRepository.save(accusation);
     }
 
+    private DisasterReportStatus resolveFinalStatus(DisasterReportStatus current, AiAnalyzeResponse aiResult) {
+        if (current == DisasterReportStatus.BLINDED) {
+            return DisasterReportStatus.BLINDED;
+        }
+        if (aiResult.trustScore() != null && aiResult.trustScore() <= 75) {
+            return DisasterReportStatus.SUSPICIOUS;
+        }
+        return DisasterReportStatus.valueOf(aiResult.status());
+    }
+
     private void analyzeReportImage(DisasterReport savedReport) {
         if (savedReport.getFileUrls() == null || savedReport.getFileUrls().isEmpty()) {
             return;
@@ -230,6 +240,7 @@ public class DisasterReportService {
 
             AiAnalyzeResponse aiResult = aiAnalyzeClient.analyze(savedReport.getId(), imageUrl);
 
+            DisasterReportStatus finalStatus = resolveFinalStatus(savedReport.getStatus(), aiResult);
             savedReport.updateAiAnalysisResult(
                     aiResult.aiGeneratedProbability(),
                     aiResult.realProbability(),
@@ -238,7 +249,7 @@ public class DisasterReportService {
                     aiResult.notInformativeProbability(),
                     aiResult.informativePrediction(),
                     aiResult.trustScore(),
-                    DisasterReportStatus.valueOf(aiResult.status())
+                    finalStatus
             );
         } catch (Exception e) {
             log.warn("AI 분석 실패 reportId={}, reason={}", savedReport.getId(), e.getMessage());


### PR DESCRIPTION
## 작업 내용
- 제보검토 신뢰도 의심 계산 및 필드 추가
- 대시보드 신뢰도 의심 <-> 블라인드 응답 바뀌어있던 오류 해결

## 특이 사항 (리뷰 시 참고할 내용)
-

### 관련 이슈
close #103 